### PR TITLE
Philiprodrigues/forward and catch

### DIFF
--- a/include/nwqueueadapters/NetworkToQueue.hpp
+++ b/include/nwqueueadapters/NetworkToQueue.hpp
@@ -125,8 +125,7 @@ public:
 private:
   // Commands
   void do_configure(const data_t&);
-  void do_start(const data_t&);
-  void do_stop(const data_t&);
+  void do_scrap(const data_t&);
 
   // Threading
   appfwk::ThreadHelper thread_;

--- a/include/nwqueueadapters/NetworkToQueue.hpp
+++ b/include/nwqueueadapters/NetworkToQueue.hpp
@@ -51,6 +51,17 @@
   }                                                                                                                    \
   }
 
+namespace dunedaq {
+// clang-format off
+ERS_DECLARE_ISSUE(nwqueueadapters,                        // namespace
+                  NetworkToQueuePushTimeout,              // issue name
+                  "Push timed out: Message of type " << t // message
+                  << " to queue " << q,
+                  ((std::string)t)((std::string)q))       // attributes
+
+// clang-format on
+}
+
 namespace dunedaq::nwqueueadapters {
 
 class NetworkToQueueBase
@@ -122,7 +133,7 @@ private:
   void do_work(std::atomic<bool>& running_flag);
 
   std::string queue_instance_;
-  
+  std::string message_type_name_;
   std::unique_ptr<NetworkToQueueBase> impl_;
 };
 

--- a/include/nwqueueadapters/QueueToNetwork.hpp
+++ b/include/nwqueueadapters/QueueToNetwork.hpp
@@ -157,8 +157,7 @@ public:
 private:
   // Commands
   void do_configure(const data_t&);
-  void do_start(const data_t&);
-  void do_stop(const data_t&);
+  void do_scrap(const data_t&);
 
   // Threading
   void do_work(std::atomic<bool>& running_flag);

--- a/plugins/NetworkToQueue.cpp
+++ b/plugins/NetworkToQueue.cpp
@@ -26,8 +26,7 @@ NetworkToQueue::NetworkToQueue(const std::string& name)
   , impl_(nullptr)
 {
   register_command("conf", &NetworkToQueue::do_configure);
-  register_command("start", &NetworkToQueue::do_start);
-  register_command("stop", &NetworkToQueue::do_stop);
+  register_command("scrap", &NetworkToQueue::do_scrap);
 }
 
 void
@@ -47,16 +46,11 @@ NetworkToQueue::do_configure(const data_t& config_data)
   if (impl_.get() == nullptr) {
     throw std::runtime_error("No NToQ for requested msg_type");
   }
-}
-
-void
-NetworkToQueue::do_start(const data_t& /*args*/)
-{
   thread_.start_working_thread();
 }
 
 void
-NetworkToQueue::do_stop(const data_t& /*args*/)
+NetworkToQueue::do_scrap(const data_t& /*args*/)
 {
   thread_.stop_working_thread();
 }

--- a/plugins/NetworkToQueue.cpp
+++ b/plugins/NetworkToQueue.cpp
@@ -41,6 +41,7 @@ NetworkToQueue::do_configure(const data_t& config_data)
 {
   auto conf = config_data.get<dunedaq::nwqueueadapters::networktoqueue::Conf>();
   auto receiver_conf = conf.receiver_config.get<dunedaq::nwqueueadapters::networkobjectreceiver::Conf>();
+  message_type_name_=conf.msg_type;
 
   impl_ = makeNetworkToQueueBase(conf.msg_module_name, conf.msg_type, queue_instance_, receiver_conf);
   if (impl_.get() == nullptr) {
@@ -70,6 +71,9 @@ NetworkToQueue::do_work(std::atomic<bool>& running_flag)
       ++recv_counter;
     } catch (ipm::ReceiveTimeoutExpired&) {
       // It's not a problem if the receive times out
+      continue;
+    } catch (const dunedaq::appfwk::QueueTimeoutExpired& e) {
+      ers::warning(NetworkToQueuePushTimeout(ERS_HERE, message_type_name_, queue_instance_, e));
       continue;
     }
   }

--- a/plugins/QueueToNetwork.cpp
+++ b/plugins/QueueToNetwork.cpp
@@ -29,8 +29,8 @@ QueueToNetwork::QueueToNetwork(const std::string& name)
 {
 
   register_command("conf", &QueueToNetwork::do_configure);
-  register_command("start", &QueueToNetwork::do_start);
-  register_command("stop", &QueueToNetwork::do_stop);
+  register_command("scrap", &QueueToNetwork::do_scrap);
+
 }
 
 void
@@ -50,16 +50,11 @@ QueueToNetwork::do_configure(const data_t& config_data)
   if (impl_.get() == nullptr) {
     throw std::runtime_error("No QToN for requested msg_type");
   }
-}
-
-void
-QueueToNetwork::do_start(const data_t& /*args*/)
-{
   thread_.start_working_thread();
 }
 
 void
-QueueToNetwork::do_stop(const data_t& /*args*/)
+QueueToNetwork::do_scrap(const data_t& /*args*/)
 {
   thread_.stop_working_thread();
 }


### PR DESCRIPTION
Fixes two issues:

1. Queue timeout on push was not being caught, causing the process to crash. That's now an ERS warning
2. Messages were being forwarded only during RUNNING. Now they're forwarded from conf until scrap (which is the "maximum" time during which we can forward, since we don't know network connections until conf)