### PR TITLE
Remove use of moo 'any' type in schema

### DIFF
--- a/plugins/NetworkToQueue.cpp
+++ b/plugins/NetworkToQueue.cpp
@@ -39,10 +39,9 @@ void
 NetworkToQueue::do_configure(const data_t& config_data)
 {
   auto conf = config_data.get<dunedaq::nwqueueadapters::networktoqueue::Conf>();
-  auto receiver_conf = conf.receiver_config.get<dunedaq::nwqueueadapters::networkobjectreceiver::Conf>();
   message_type_name_=conf.msg_type;
 
-  impl_ = makeNetworkToQueueBase(conf.msg_module_name, conf.msg_type, queue_instance_, receiver_conf);
+  impl_ = makeNetworkToQueueBase(conf.msg_module_name, conf.msg_type, queue_instance_, conf.receiver_config);
   if (impl_.get() == nullptr) {
     throw std::runtime_error("No NToQ for requested msg_type");
   }

--- a/plugins/QueueToNetwork.cpp
+++ b/plugins/QueueToNetwork.cpp
@@ -43,10 +43,9 @@ void
 QueueToNetwork::do_configure(const data_t& config_data)
 {
   auto conf = config_data.get<dunedaq::nwqueueadapters::queuetonetwork::Conf>();
-  auto sender_conf = conf.sender_config.get<dunedaq::nwqueueadapters::networkobjectsender::Conf>();
   message_type_name_=conf.msg_type;
 
-  impl_ = makeQueueToNetworkBase(conf.msg_module_name, message_type_name_, queue_instance_, sender_conf);
+  impl_ = makeQueueToNetworkBase(conf.msg_module_name, message_type_name_, queue_instance_, conf.sender_config);
   if (impl_.get() == nullptr) {
     throw std::runtime_error("No QToN for requested msg_type");
   }

--- a/schema/nwqueueadapters/networktoqueue.jsonnet
+++ b/schema/nwqueueadapters/networktoqueue.jsonnet
@@ -7,6 +7,8 @@
 
 local moo = import "moo.jsonnet";
 
+local s_nor = import "networkobjectreceiver.jsonnet";
+local nor = moo.oschema.hier(s_nor).dunedaq.nwqueueadapters.networkobjectreceiver;
 // A schema builder in the given path (namespace)
 local ns = "dunedaq.nwqueueadapters.networktoqueue";
 local s = moo.oschema.schema(ns);
@@ -16,16 +18,14 @@ local ntoq = {
   name: s.string("Name", ".*",
     doc="Name of a plugin etc"),
 
-  any: s.any("Data", doc="Any"),
-  
   conf: s.record("Conf", [
     s.field("msg_type", self.name,
       doc="The fully-qualified name of the type in the queue"),
     s.field("msg_module_name", self.name,
       doc="The name of the plugin containing the code for the message type"),
-    s.field("receiver_config", self.any,
+    s.field("receiver_config", nor.Conf,
       doc="Configuration for the NetworkObjectReceiver"),
   ], doc="NetworkToQueueAdapterDAQModule Configuration"),
 };
 
-moo.oschema.sort_select(ntoq)
+s_nor + moo.oschema.sort_select(ntoq)

--- a/schema/nwqueueadapters/queuetonetwork.jsonnet
+++ b/schema/nwqueueadapters/queuetonetwork.jsonnet
@@ -7,6 +7,9 @@
 
 local moo = import "moo.jsonnet";
 
+local s_nos = import "networkobjectsender.jsonnet";
+local nos = moo.oschema.hier(s_nos).dunedaq.nwqueueadapters.networkobjectsender;
+
 // A schema builder in the given path (namespace)
 local ns = "dunedaq.nwqueueadapters.queuetonetwork";
 local s = moo.oschema.schema(ns);
@@ -16,16 +19,14 @@ local qton = {
   name: s.string("Name", ".*",
     doc="Name of a plugin etc"),
 
-  any: s.any("Data", doc="Any"),
-
   conf: s.record("Conf", [
     s.field("msg_type", self.name,
       doc="The fully-qualified name of the type in the queue"),
     s.field("msg_module_name", self.name,
       doc="The name of the plugin containing the code for the message type"),
-    s.field("sender_config", self.any,
+    s.field("sender_config", nos.Conf,
       doc="Configuration for the NetworkObjectSender"),
   ], doc="NetworkToQueueAdapterDAQModule Configuration"),
 };
 
-moo.oschema.sort_select(qton)
+s_nos + moo.oschema.sort_select(qton)


### PR DESCRIPTION
This PR replaces the use of the moo "any" type with the actual schema types that the fields represent