### PR TITLE
Run clang-format on files, implement some lint fixes.

### DIFF
--- a/include/nwqueueadapters/AdapterMacros.hpp
+++ b/include/nwqueueadapters/AdapterMacros.hpp
@@ -14,8 +14,9 @@
 #include "nwqueueadapters/NetworkToQueue.hpp"
 #include "nwqueueadapters/QueueToNetwork.hpp"
 
+// NOLINTNEXTLINE(build/define_used)
 #define DEFINE_DUNE_NWQUEUEADAPTERS(...)                                                                               \
   DEFINE_DUNE_QUEUE_TO_NETWORK(__VA_ARGS__)                                                                            \
   DEFINE_DUNE_NETWORK_TO_QUEUE(__VA_ARGS__)
 
-#endif
+#endif // NWQUEUEADAPTERS_INCLUDE_NWQUEUEADAPTERS_ADAPTERMACROS_HPP_

--- a/include/nwqueueadapters/Issues.hpp
+++ b/include/nwqueueadapters/Issues.hpp
@@ -1,7 +1,18 @@
+/**
+ * @file Issues.hpp
+ *
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
 #ifndef NWQUEUEADAPTERS_INCLUDE_NWQUEUEADAPTERS_ISSUES_HPP_
 #define NWQUEUEADAPTERS_INCLUDE_NWQUEUEADAPTERS_ISSUES_HPP_
 
 #include "ers/Issue.hpp"
+
+#include <string>
 
 namespace dunedaq {
 // clang-format off
@@ -46,6 +57,6 @@ ERS_DECLARE_ISSUE(nwqueueadapters,                                        // nam
                   ((std::string)queue_instance))
 
 // clang-format on
-}
+} // namespace dunedaq
 
-#endif
+#endif // NWQUEUEADAPTERS_INCLUDE_NWQUEUEADAPTERS_ISSUES_HPP_

--- a/include/nwqueueadapters/NetworkToQueue.hpp
+++ b/include/nwqueueadapters/NetworkToQueue.hpp
@@ -14,7 +14,12 @@
 #include "appfwk/DAQModule.hpp"
 #include "appfwk/DAQSink.hpp"
 #include "appfwk/ThreadHelper.hpp"
+#include "appfwk/cmd/Nljs.hpp"
+#include "nwqueueadapters/Issues.hpp"
+#include "nwqueueadapters/NetworkObjectReceiver.hpp"
+#include "serialization/Serialization.hpp"
 
+#include "boost/preprocessor.hpp"
 #include <cetlib/BasicPluginFactory.h>
 #include <cetlib/compiler_macros.h>
 
@@ -22,28 +27,22 @@
 #include <string>
 #include <vector>
 
-#include "appfwk/cmd/Nljs.hpp"
-
-#include "nwqueueadapters/Issues.hpp"
-#include "nwqueueadapters/NetworkObjectReceiver.hpp"
-
-#include "serialization/Serialization.hpp"
-
-#include "boost/preprocessor.hpp"
-
 #ifndef EXTERN_C_FUNC_DECLARE_START
+// NOLINTNEXTLINE(build/define_used)
 #define EXTERN_C_FUNC_DECLARE_START                                                                                    \
   extern "C"                                                                                                           \
   {
 #endif
 
+// NOLINTNEXTLINE(build/define_used)
 #define MAKENQIMPL(r, data, klass)                                                                                     \
   if (plugin_name == BOOST_PP_STRINGIZE(klass))                                                                        \
-    return std::make_unique<dunedaq::nwqueueadapters::NetworkToQueueImpl<klass>>(queue_instance, receiver_conf);
+    return std::make_unique<dunedaq::nwqueueadapters::NetworkToQueueImpl<klass>>(queue_instance, receiver_conf); // NOLINT
 /**
  * @brief Declare the function that will be called by the plugin loader
  * @param klass Class for which a NetworkToQueue module will be used
  */
+// NOLINTNEXTLINE(build/define_used)
 #define DEFINE_DUNE_NETWORK_TO_QUEUE(...)                                                                              \
   EXTERN_C_FUNC_DECLARE_START                                                                                          \
   std::unique_ptr<dunedaq::nwqueueadapters::NetworkToQueueBase> makeNToQ(                                              \
@@ -61,7 +60,14 @@ namespace dunedaq::nwqueueadapters {
 class NetworkToQueueBase
 {
 public:
+  NetworkToQueueBase() = default;
   virtual ~NetworkToQueueBase() = default;
+
+  NetworkToQueueBase(NetworkToQueueBase const&) = delete;
+  NetworkToQueueBase(NetworkToQueueBase&&) = default;
+  NetworkToQueueBase& operator=(NetworkToQueueBase const&) = delete;
+  NetworkToQueueBase& operator=(NetworkToQueueBase&&) = default;
+
   virtual void push() = 0;
 };
 

--- a/include/nwqueueadapters/QueueToNetwork.hpp
+++ b/include/nwqueueadapters/QueueToNetwork.hpp
@@ -14,6 +14,10 @@
 #include "appfwk/DAQModule.hpp"
 #include "appfwk/DAQSource.hpp"
 #include "appfwk/ThreadHelper.hpp"
+#include "appfwk/cmd/Nljs.hpp"
+#include "nwqueueadapters/Issues.hpp"
+#include "nwqueueadapters/NetworkObjectSender.hpp"
+#include "serialization/Serialization.hpp"
 
 #include <ers/Issue.hpp>
 
@@ -24,26 +28,22 @@
 #include <string>
 #include <vector>
 
-#include "appfwk/cmd/Nljs.hpp"
-
-#include "nwqueueadapters/Issues.hpp"
-#include "nwqueueadapters/NetworkObjectSender.hpp"
-
-#include "serialization/Serialization.hpp"
-
 #ifndef EXTERN_C_FUNC_DECLARE_START
+// NOLINTNEXTLINE(build/define_used)
 #define EXTERN_C_FUNC_DECLARE_START                                                                                    \
   extern "C"                                                                                                           \
   {
 #endif
 
+// NOLINTNEXTLINE(build/define_used)
 #define MAKEQNIMPL(r, data, klass)                                                                                     \
   if (plugin_name == BOOST_PP_STRINGIZE(klass))                                                                        \
-    return std::make_unique<dunedaq::nwqueueadapters::QueueToNetworkImpl<klass>>(queue_instance, sender_conf);
+    return std::make_unique<dunedaq::nwqueueadapters::QueueToNetworkImpl<klass>>(queue_instance, sender_conf); // NOLINT
 /**
  * @brief Declare the function that will be called by the plugin loader
  * @param klass Class for which a QueueToNetwork module will be used
  */
+// NOLINTNEXTLINE(build/define_used)
 #define DEFINE_DUNE_QUEUE_TO_NETWORK(...)                                                                              \
   EXTERN_C_FUNC_DECLARE_START                                                                                          \
   std::unique_ptr<dunedaq::nwqueueadapters::QueueToNetworkBase> makeQToN(                                              \
@@ -82,7 +82,13 @@ namespace dunedaq::nwqueueadapters {
 class QueueToNetworkBase
 {
 public:
+  QueueToNetworkBase() = default;
   virtual ~QueueToNetworkBase() = default;
+
+  QueueToNetworkBase(QueueToNetworkBase const&) = delete;
+  QueueToNetworkBase(QueueToNetworkBase&&) = default;
+  QueueToNetworkBase& operator=(QueueToNetworkBase const&) = delete;
+  QueueToNetworkBase& operator=(QueueToNetworkBase&&) = default;
 
   virtual void get() = 0;
 };

--- a/plugins/NetworkToQueue.cpp
+++ b/plugins/NetworkToQueue.cpp
@@ -8,11 +8,10 @@
 
 #include "nwqueueadapters/NetworkToQueue.hpp"
 
-#include "nwqueueadapters/networkobjectreceiver/Nljs.hpp"
-#include "nwqueueadapters/networktoqueue/Nljs.hpp"
-
 #include "appfwk/DAQModuleHelper.hpp"
 #include "logging/Logging.hpp"
+#include "nwqueueadapters/networkobjectreceiver/Nljs.hpp"
+#include "nwqueueadapters/networktoqueue/Nljs.hpp"
 
 #include <chrono>
 #include <string>

--- a/plugins/QueueToNetwork.cpp
+++ b/plugins/QueueToNetwork.cpp
@@ -1,5 +1,6 @@
 /**
- *
+ * @file QueueToNetwork.cpp
+ * 
  * This is part of the DUNE DAQ Application Framework, copyright 2020.
  * Licensing/copyright details are in the COPYING file that you should have
  * received with this code.
@@ -7,19 +8,18 @@
 
 #include "nwqueueadapters/QueueToNetwork.hpp"
 
-#include <chrono>
-#include <ers/Severity.hpp>
-#include <ers/ers.hpp>
-#include <string>
-#include <vector>
-
 #include "appfwk/DAQModuleHelper.hpp"
-
 #include "nwqueueadapters/Issues.hpp"
-#include "serialization/Serialization.hpp"
-
 #include "nwqueueadapters/networkobjectsender/Nljs.hpp"
 #include "nwqueueadapters/queuetonetwork/Nljs.hpp"
+#include "serialization/Serialization.hpp"
+
+#include <ers/Severity.hpp>
+#include <ers/ers.hpp>
+
+#include <chrono>
+#include <string>
+#include <vector>
 
 namespace dunedaq::nwqueueadapters {
 

--- a/src/dummy.cpp
+++ b/src/dummy.cpp
@@ -1,2 +1,10 @@
-// This file only exists so that the CMake build can create a library for this package, via the daq_add_library() CMake
-// function
+/**
+ * @file dummy.cpp
+ *
+ * This file only exists so that the CMake build can create a library for this package, via the daq_add_library() CMake
+ * function
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */

--- a/test/apps/network_object_send_receive.cxx
+++ b/test/apps/network_object_send_receive.cxx
@@ -1,3 +1,11 @@
+/**
+ * @file network_object_send_receive.cxx
+ * 
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
 #include "nwqueueadapters/NetworkObjectReceiver.hpp"
 #include "nwqueueadapters/NetworkObjectSender.hpp"
 // clang-format off

--- a/test/plugins/FakeDataConsumer.hpp
+++ b/test/plugins/FakeDataConsumer.hpp
@@ -60,7 +60,7 @@ private:
   std::unique_ptr<dunedaq::appfwk::DAQSource<fsd::FakeData>> inputQueue_;
 };
 
-} // namespace appfwk
+} // namespace nwqueueadapters
 ERS_DECLARE_ISSUE_BASE(nwqueueadapters,
                        ConsumerProgressUpdate,
                        appfwk::GeneralDAQModuleIssue,


### PR DESCRIPTION
Still a few linting issues remain from #14, mostly in the test/ directory:

```
sourcecode/nwqueueadapters/plugins/QueueToNetwork.cpp:67:  Missing author name in TODO comment; it should appear on the same line as the TODO, as Firstname Lastname  [readability/todo] [2]
sourcecode/nwqueueadapters/plugins/QueueToNetwork.cpp:67:  Missing date in TODO comment; it should appear on same line as the TODO, preferably in a form like "Apr-14-2020"  [readability/todo] [2]
sourcecode/nwqueueadapters/plugins/QueueToNetwork.cpp:67:  Missing email address in TODO comment; it should appear on the same line as the TODO  [readability/todo] [2]
sourcecode/nwqueueadapters/test/apps/network_object_send_receive.cxx:13:  Found other header after system header. Should be: network_object_send_receive.hh, other non-system headers, system headers.  [build/include_order] [4]
sourcecode/nwqueueadapters/test/apps/network_object_send_receive.cxx:14:  Found other header after system header. Should be: network_object_send_receive.hh, other non-system headers, system headers.  [build/include_order] [4]
sourcecode/nwqueueadapters/test/apps/network_object_send_receive.cxx:15:  Found other header after system header. Should be: network_object_send_receive.hh, other non-system headers, system headers.  [build/include_order] [4]
sourcecode/nwqueueadapters/test/apps/network_object_send_receive.cxx:42:  "cout" should not be used for output in DUNE DAQ software.  [runtime/output_format] [3]
sourcecode/nwqueueadapters/test/apps/serialization_speed.cxx:0:  The standard copyright message wasn't found.  [legal/copyright] [5]
sourcecode/nwqueueadapters/test/apps/serialization_speed.cxx:41:  "cout" should not be used for output in DUNE DAQ software.  [runtime/output_format] [3]
sourcecode/nwqueueadapters/test/apps/serialization_speed.cxx:45:  An unsigned integer appears to be used here.  [build/unsigned] [3]
sourcecode/nwqueueadapters/test/apps/serialization_speed.cxx:5:  Found other header after system header. Should be: serialization_speed.hh, other non-system headers, system headers.  [build/include_order] [4]
sourcecode/nwqueueadapters/test/apps/serialization_speed.cxx:66:  An unsigned integer appears to be used here.  [build/unsigned] [3]
sourcecode/nwqueueadapters/test/apps/serialization_speed.cxx:6:  Found other header after system header. Should be: serialization_speed.hh, other non-system headers, system headers.  [build/include_order] [4]
sourcecode/nwqueueadapters/test/apps/serialization_speed.cxx:71:  An unsigned integer appears to be used here.  [build/unsigned] [3]
sourcecode/nwqueueadapters/test/apps/serialization_speed.cxx:74:  "printf" should not be used for output in DUNE DAQ software.  [runtime/output_format] [3]
sourcecode/nwqueueadapters/test/apps/serialization_speed.cxx:7:  Found other header after system header. Should be: serialization_speed.hh, other non-system headers, system headers.  [build/include_order] [4]
sourcecode/nwqueueadapters/test/src/nwqueueadapters/fsd/MsgP.hpp:0:  The standard copyright message wasn't found.  [legal/copyright] [5]
sourcecode/nwqueueadapters/test/src/nwqueueadapters/fsd/MsgP.hpp:1:  C-style comment syntax detected; please use either C++ style "//" or Doxygen style  [readability/comment] [3]
sourcecode/nwqueueadapters/test/src/nwqueueadapters/fsd/MsgP.hpp:7:  #ifndef header guard has wrong style, please use: NWQUEUEADAPTERS_TEST_SRC_NWQUEUEADAPTERS_FSD_MSGP_HPP_  [build/header_guard] [5]
sourcecode/nwqueueadapters/test/src/nwqueueadapters/fsd/MsgP.hpp:90:  #endif line should be "#endif  // NWQUEUEADAPTERS_TEST_SRC_NWQUEUEADAPTERS_FSD_MSGP_HPP_"  [build/header_guard] [5]
```