### PR TITLE
Add opmon to NetworkToQueue and QueueToNetwork

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,11 +10,32 @@ find_package(logging REQUIRED)
 find_package(ipm REQUIRED)
 find_package(nlohmann_json REQUIRED)
 find_package(serialization REQUIRED)
+find_package(opmonlib REQUIRED)
 
 ##############################################################################
 # Schema
 
-daq_codegen(*.jsonnet TEMPLATES Structs.hpp.j2 Nljs.hpp.j2 MsgP.hpp.j2 )
+daq_codegen(
+  fakedataconsumer.jsonnet
+  fakedataproducer.jsonnet
+  networkobjectreceiver.jsonnet
+  networkobjectsender.jsonnet
+  networktoqueueinfo.jsonnet
+  networktoqueue.jsonnet
+  queuetonetworkinfo.jsonnet
+  queuetonetwork.jsonnet
+  TEMPLATES Structs.hpp.j2 Nljs.hpp.j2
+)
+
+daq_codegen(
+  fsd.jsonnet
+  TEMPLATES Structs.hpp.j2 Nljs.hpp.j2 MsgP.hpp.j2 )
+
+daq_codegen(
+  networktoqueueinfo.jsonnet
+  queuetonetworkinfo.jsonnet
+  DEP_PKGS opmonlib TEMPLATES opmonlib/InfoStructs.hpp.j2 opmonlib/InfoNljs.hpp.j2
+)
 
 ##############################################################################
 # Main library

--- a/include/nwqueueadapters/NetworkToQueue.hpp
+++ b/include/nwqueueadapters/NetworkToQueue.hpp
@@ -17,6 +17,7 @@
 #include "appfwk/cmd/Nljs.hpp"
 #include "nwqueueadapters/Issues.hpp"
 #include "nwqueueadapters/NetworkObjectReceiver.hpp"
+#include "nwqueueadapters/networktoqueueinfo/InfoNljs.hpp"
 #include "serialization/Serialization.hpp"
 
 #include "boost/preprocessor.hpp"
@@ -122,6 +123,8 @@ public:
 
   void init(const data_t&) override;
 
+  void get_info(opmonlib::InfoCollector& ci, int level) override;
+  
 private:
   // Commands
   void do_configure(const data_t&);
@@ -134,6 +137,9 @@ private:
   std::string m_queue_instance;
   std::string m_message_type_name;
   std::unique_ptr<NetworkToQueueBase> m_impl;
+
+  networktoqueueinfo::Info m_opmon_info;
+  std::mutex m_opmon_mutex;
 };
 
 std::unique_ptr<NetworkToQueueBase>

--- a/include/nwqueueadapters/QueueToNetwork.hpp
+++ b/include/nwqueueadapters/QueueToNetwork.hpp
@@ -17,7 +17,9 @@
 #include "appfwk/cmd/Nljs.hpp"
 #include "nwqueueadapters/Issues.hpp"
 #include "nwqueueadapters/NetworkObjectSender.hpp"
+#include "nwqueueadapters/queuetonetworkinfo/InfoNljs.hpp"
 #include "serialization/Serialization.hpp"
+
 
 #include <ers/Issue.hpp>
 
@@ -150,6 +152,8 @@ public:
 
   void init(const data_t&) override;
 
+  void get_info(opmonlib::InfoCollector& ci, int level) override;
+  
 private:
   // Commands
   void do_configure(const data_t&);
@@ -162,7 +166,11 @@ private:
   std::string m_queue_instance;
   std::string m_message_type_name;
   std::unique_ptr<QueueToNetworkBase> m_impl;
+
+  queuetonetworkinfo::Info m_opmon_info;
+  std::mutex m_opmon_mutex;
 };
+
 
 std::unique_ptr<QueueToNetworkBase>
 makeQueueToNetworkBase(std::string const& module_name,

--- a/schema/nwqueueadapters/networktoqueueinfo.jsonnet
+++ b/schema/nwqueueadapters/networktoqueueinfo.jsonnet
@@ -1,0 +1,19 @@
+// This is the application info schema used by NetworkToQueue
+// It describes the information object structure passed by the application 
+// for operational monitoring
+
+local moo = import "moo.jsonnet";
+local s = moo.oschema.schema("dunedaq.nwqueueadapters.networktoqueueinfo");
+
+local info = {
+    uint8  : s.number("uint8", "u8",
+                     doc="An unsigned of 8 bytes"),
+
+   info: s.record("Info", [
+       s.field("received_count",    self.uint8, 0, doc="Number of messages received on network"), 
+       s.field("pushed_count",      self.uint8, 0, doc="Number of items successfully pushed to queue"), 
+       s.field("push_failed_count", self.uint8, 0, doc="Number of timeouts pushing to queue"), 
+   ], doc="NetworkToQueue information")
+};
+
+moo.oschema.sort_select(info) 

--- a/schema/nwqueueadapters/queuetonetworkinfo.jsonnet
+++ b/schema/nwqueueadapters/queuetonetworkinfo.jsonnet
@@ -1,0 +1,19 @@
+// This is the application info schema used by QueueToNetwork
+// It describes the information object structure passed by the application 
+// for operational monitoring
+
+local moo = import "moo.jsonnet";
+local s = moo.oschema.schema("dunedaq.nwqueueadapters.queuetonetworkinfo");
+
+local info = {
+    uint8  : s.number("uint8", "u8",
+                     doc="An unsigned of 8 bytes"),
+
+   info: s.record("Info", [
+       s.field("popped_count",      self.uint8, 0, doc="Number of items popped from input queue"), 
+       s.field("sent_count",        self.uint8, 0, doc="Number of items successfully sent to network"), 
+       s.field("send_failed_count", self.uint8, 0, doc="Number of timeouts sending to network"), 
+   ], doc="NetworkToQueue information")
+};
+
+moo.oschema.sort_select(info) 


### PR DESCRIPTION
This PR adds operational monitoring to NetworkToQueue and QueueToNetwork, with counts of received/sent items and items that failed to send/push, as appropriate