### PR TITLE
Fix data loss when messages sent during conf

### DIFF
--- a/include/nwqueueadapters/Issues.hpp
+++ b/include/nwqueueadapters/Issues.hpp
@@ -24,6 +24,15 @@ ERS_DECLARE_ISSUE(nwqueueadapters,                        // namespace
                   )                                       // (no attributes)
 
 ERS_DECLARE_ISSUE(nwqueueadapters,                        // namespace
+                  ReceiverNotReady,                       // issue name
+                  "Receiver not ready in QueueToNetwork"  // message
+                  << " with queue \"" << queue
+                  << "\", connection " << connection
+                  << ". Ensure that receiving NetworkToQueue is configured before sender",
+                  ((std::string)queue)                    // attributes
+                  ((std::string)connection))
+
+ERS_DECLARE_ISSUE(nwqueueadapters,                        // namespace
                   NetworkToQueuePushTimeout,              // issue name
                   "Push timed out: Message of type " << t // message
                   << " to queue " << q,
@@ -56,7 +65,7 @@ ERS_DECLARE_ISSUE(nwqueueadapters,                                        // nam
                   ((std::string)klass)                                    // attributes
                   ((std::string)library)
                   ((std::string)queue_instance))
-    
+
     // LCOV_EXCL_STOP
 // clang-format on
 } // namespace dunedaq

--- a/include/nwqueueadapters/NetworkObjectReceiver.hpp
+++ b/include/nwqueueadapters/NetworkObjectReceiver.hpp
@@ -18,6 +18,8 @@
 #include "ipm/Receiver.hpp"
 
 #include <memory> // for shared_ptr
+#include <variant>
+
 namespace dunedaq::nwqueueadapters {
 
 /**
@@ -55,10 +57,25 @@ public:
     }
   }
 
-  T recv(const dunedaq::ipm::Receiver::duration_t& timeout)
+  /**
+   * @brief Receive a control message or object
+   *
+   * Incoming messages may be "control" messages consisting of a
+   * single byte, or serialized objects. In the former case, the
+   * returned std::variant holds a char with the content of the
+   * control message; in the latter case, the variant holds an object
+   * of class T deserialized from the message
+   **/
+  std::variant<char, T> recv(const dunedaq::ipm::Receiver::duration_t& timeout)
   {
     dunedaq::ipm::Receiver::Response recvd = m_receiver->receive(timeout);
-    return serialization::deserialize<T>(recvd.data);
+    // Messages consisting of a single byte are control messages; others are serialized objects
+    if (recvd.data.size()==1) {
+      return recvd.data[0];
+    }
+    else{
+      return serialization::deserialize<T>(recvd.data);
+    }
   }
 
 protected:

--- a/include/nwqueueadapters/NetworkObjectSender.hpp
+++ b/include/nwqueueadapters/NetworkObjectSender.hpp
@@ -51,7 +51,16 @@ public:
   {
     m_sender->connect_for_sends({ { "connection_string", conf.address } });
   }
-
+  
+  /**
+   * @brief Send a control message consisting of a single byte @p c
+   */
+  void send_control_message(char c, const dunedaq::ipm::Sender::duration_t& timeout)
+  {
+    std::vector<char> bytes{c};
+    m_sender->send(bytes.data(), bytes.size(), timeout, m_conf.topic);
+  }
+  
   /**
    * @brief Send object @p obj with timeout @p timeout
    */

--- a/include/nwqueueadapters/NetworkToQueue.hpp
+++ b/include/nwqueueadapters/NetworkToQueue.hpp
@@ -26,6 +26,7 @@
 
 #include <memory>
 #include <string>
+#include <variant>
 #include <vector>
 
 #ifndef EXTERN_C_FUNC_DECLARE_START
@@ -88,7 +89,13 @@ public:
 
   virtual void push()
   {
-    m_output_queue->push(m_receiver.recv(std::chrono::milliseconds(10)), std::chrono::milliseconds(10));
+    std::variant<char, T> incoming=m_receiver.recv(std::chrono::milliseconds(10));
+    if (std::holds_alternative<char>(incoming)) {
+      // So far the only control message is the "test connection" message, which we ignore
+    }
+    else if (std::holds_alternative<T>(incoming)) {
+      m_output_queue->push(std::get<T>(incoming), std::chrono::milliseconds(10));
+    }
   }
 
 private:

--- a/include/nwqueueadapters/QueueToNetwork.hpp
+++ b/include/nwqueueadapters/QueueToNetwork.hpp
@@ -149,7 +149,7 @@ public:
     // message loss, you have to use something other than Publisher.)
     
     try{
-      m_sender.send_control_message('\0', std::chrono::milliseconds(1000));
+      m_sender.send_control_message('\0', std::chrono::milliseconds(sender_conf.control_timeout));
     } catch (ipm::SendTimeoutExpired& e) {
       throw ReceiverNotReady(ERS_HERE, queue_instance, sender_conf.address, e);
     }

--- a/schema/nwqueueadapters/networkobjectsender.jsonnet
+++ b/schema/nwqueueadapters/networkobjectsender.jsonnet
@@ -15,6 +15,9 @@ local nos = {
   address: s.string("Address", doc="Address to send to"),
 
   topic: s.string("Topic", doc="A topic string for publisher-type senders"),
+
+  timeout : s.number("Count", "u8",
+                     doc="A number of milliseconds to wait for something"),
   
   conf: s.record("Conf",  [
     s.field("stype", self.stype, "msgpack",
@@ -24,7 +27,8 @@ local nos = {
     s.field("address", self.address, "inproc://default",
       doc="Address to send to"),
     s.field("topic", self.topic, "",
-      doc="topic for publisher-type senders")
+      doc="topic for publisher-type senders"),
+    s.field("control_timeout", self.timeout, 1000, doc="Timeout for sending the initial control message")
   ], doc="NetworkObjectSender Configuration"),
   
 };

--- a/test/apps/network_object_send_receive.cxx
+++ b/test/apps/network_object_send_receive.cxx
@@ -39,6 +39,6 @@ main()
   fd.fake_count = 25;
 
   sender.send(fd, std::chrono::milliseconds(2));
-  FakeData fd_recv = receiver.recv(std::chrono::milliseconds(2));
+  FakeData fd_recv = std::get<FakeData>(receiver.recv(std::chrono::milliseconds(2)));
   TLOG() << "Sent: " << fd.fake_count << ". Received: " << fd_recv.fake_count << std::endl;
 }

--- a/test/apps/serialization_speed.cxx
+++ b/test/apps/serialization_speed.cxx
@@ -45,7 +45,7 @@ receiver_thread_fn(dunedaq::nwqueueadapters::networkobjectreceiver::Conf receive
   int total = 0;
   dunedaq::nwqueueadapters::NetworkObjectReceiver<FakeData> receiver(receiver_conf);
   for (int i = 0; i < n_messages; ++i) {
-    FakeData fd_recv = receiver.recv(std::chrono::milliseconds(1000000));
+    FakeData fd_recv = std::get<FakeData>(receiver.recv(std::chrono::milliseconds(1000000)));
     total += fd_recv.fake_count;
   }
   TLOG() << "Total:" << total << std::endl;

--- a/unittest/NOR_NOS_test.cxx
+++ b/unittest/NOR_NOS_test.cxx
@@ -61,7 +61,7 @@ BOOST_DATA_TEST_CASE(NetworkObjectSenderReceiver, boost::unit_test::data::make({
   m.values.push_back(2.781);
 
   sender.send(m, std::chrono::milliseconds(2));
-  MyTypeIntrusive m_recv = receiver.recv(std::chrono::milliseconds(2));
+  MyTypeIntrusive m_recv = std::get<MyTypeIntrusive>(receiver.recv(std::chrono::milliseconds(2)));
 
   BOOST_CHECK_EQUAL(m_recv.count, m.count);
   BOOST_CHECK_EQUAL(m_recv.name, m.name);


### PR DESCRIPTION
## Problem

Suppose we have:

```
  ModuleA --q1--> Q2N (ipm::Sender) ==network==> N2Q --q2--> ModuleB
```

And both:

* ModuleA is sent "conf" before ModuleB
* ModuleA pushes to q1 during its do_configure() function

Then Q2N will pop the item off its queue and attempt to send
the item _before_ ModuleB connects. The connection is not yet
made, and so the network send() times out and the item is
dropped. Q2N has no way to tell ModuleA that the item has been
dropped, so we get silent data loss.

## Solution/Workaround

We add the concept of "control" messages to
NetworkObjectSender/NetworkObjectReceiver, in addition to regular
messages that contain a serialized object. Then Q2N sends a single
"control" message before it starts popping items from the input
queue. If this message times out, we throw an exception and so never
get to the point where we're popping items from the input queue.

In practice, this means that the configure command will fail when a
Q2N is configured before its corresponding N2Q. That stops the whole
application. This is kind of ugly, but it's better than silently
dropping data.