### PR TITLE
Don't warn on queue-push timeout when incoming socket is subscriber-type

### DIFF
--- a/include/nwqueueadapters/NetworkToQueue.hpp
+++ b/include/nwqueueadapters/NetworkToQueue.hpp
@@ -143,6 +143,7 @@ private:
 
   std::string m_queue_instance;
   std::string m_message_type_name;
+  bool m_is_subscriber_type;
   std::unique_ptr<NetworkToQueueBase> m_impl;
 
   networktoqueueinfo::Info m_opmon_info;

--- a/plugins/NetworkToQueue.cpp
+++ b/plugins/NetworkToQueue.cpp
@@ -80,11 +80,15 @@ NetworkToQueue::do_work(std::atomic<bool>& running_flag)
     } catch (const dunedaq::appfwk::QueueTimeoutExpired& e) {
 
       auto issue = NetworkToQueuePushTimeout(ERS_HERE, m_message_type_name, m_queue_instance, e);
+      // If we're connected to a "subscriber" type socket, it's ~OK to drop
+      // messages
       if (m_is_subscriber_type) {
+        TLOG_DEBUG(1) << get_name() << ": Push of message type " << m_message_type_name << " to queue "
+                      << m_queue_instance
+                      << " timed out. Ignoring because incoming socket is "
+                         "subscriber type";
+      } else {
         ers::warning(issue);
-      }
-      else {
-        TLOG_DEBUG(1) << issue;
       }
 
       std::lock_guard<std::mutex> _(m_opmon_mutex);


### PR DESCRIPTION
If the incoming socket to a `NetworkToQueue` is a "subscriber" type, then dropping messages is ~OK. So, if the push-to-queue fails, print a debug message like this, instead of a warning:

```
2021-Aug-11 11:57:23,446 DEBUG_1 [void dunedaq::nwqueueadapters::NetworkToQueue::do_work(std::atomic<bool>&) at /home/phrodrig/dunedaq-pre-v2.8.0-nightlies/tp-rate-N21-08-10/sourcecode/nwqueueadapters/plugins/NetworkToQueue.cpp:79] ntoq_timesync_33: Push of message type dunedaq::dfmessages::TimeSync to queue time_sync_from_netq timed out. Ignoring because incoming socket is subscriber type
```