### PR TITLE
feature/iomanager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -60,7 +60,7 @@ daq_add_plugin( NetworkToQueue duneDAQModule LINK_LIBRARIES nwqueueadapters )
 
 daq_add_plugin( FakeData duneNetworkQueue TEST LINK_LIBRARIES nwqueueadapters )
 
-daq_add_application( fake_data_send_receive fake_data_send_receive.cxx TEST LINK_LIBRARIES nwqueueadapters )
+#daq_add_application( fake_data_send_receive fake_data_send_receive.cxx TEST LINK_LIBRARIES nwqueueadapters )
 daq_add_application( network_object_send_receive network_object_send_receive.cxx TEST LINK_LIBRARIES nwqueueadapters )
 daq_add_application( serialization_speed serialization_speed.cxx TEST LINK_LIBRARIES nwqueueadapters )
 

--- a/include/nwqueueadapters/NetworkToQueue.hpp
+++ b/include/nwqueueadapters/NetworkToQueue.hpp
@@ -28,6 +28,8 @@
 #include <string>
 #include <vector>
 
+#pragma message("NetworkToQueue is deprecated! Please remove your NQ classes, as they are no longer needed!")
+
 #ifndef EXTERN_C_FUNC_DECLARE_START
 // NOLINTNEXTLINE(build/define_used)
 #define EXTERN_C_FUNC_DECLARE_START                                                                                    \

--- a/include/nwqueueadapters/QueueToNetwork.hpp
+++ b/include/nwqueueadapters/QueueToNetwork.hpp
@@ -29,6 +29,8 @@
 #include <string>
 #include <vector>
 
+#pragma message("QueueToNetwork is deprecated! Please remove your NQ classes, as they are no longer needed!")
+
 #ifndef EXTERN_C_FUNC_DECLARE_START
 // NOLINTNEXTLINE(build/define_used)
 #define EXTERN_C_FUNC_DECLARE_START                                                                                    \


### PR DESCRIPTION
Don't build test application that relies on QueueRegistry. Inform users of NetworkToQueue and QueueToNetwork deprecation.